### PR TITLE
Add Standalone Apple Pay & Google Pay Nonce Support and `isShippingAddressRequired` Flag for PayPal in Flutter Braintree

### DIFF
--- a/android/src/main/java/com/example/flutter_braintree/FlutterBraintreeCustom.java
+++ b/android/src/main/java/com/example/flutter_braintree/FlutterBraintreeCustom.java
@@ -21,6 +21,8 @@ import com.braintreepayments.api.UserCanceledException;
 
 
 import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.List;
 
 public class FlutterBraintreeCustom extends AppCompatActivity implements PayPalListener {
     private BraintreeClient braintreeClient;
@@ -41,6 +43,10 @@ public class FlutterBraintreeCustom extends AppCompatActivity implements PayPalL
                 payPalClient = new PayPalClient(this, braintreeClient);
                 payPalClient.setListener(this);
                 requestPaypalNonce();
+            } else if (type.equals("requestGooglePayNonce")) {
+                requestGooglePayNonce();
+            } else if (type.equals("requestApplePayNonce")) {
+                requestApplePayNonce();
             } else {
                 throw new Exception("Invalid request type: " + type);
             }
@@ -106,6 +112,28 @@ public class FlutterBraintreeCustom extends AppCompatActivity implements PayPalL
             checkOutRequest.setCurrencyCode(intent.getStringExtra("currencyCode"));
             payPalClient.tokenizePayPalAccount(this, checkOutRequest);
         }
+    }
+
+    protected void requestGooglePayNonce() {
+        Intent intent = getIntent();
+        GooglePaymentRequest request = new GooglePaymentRequest()
+                .transactionInfo(TransactionInfo.newBuilder()
+                        .setTotalPrice(intent.getStringExtra("totalPrice"))
+                        .setTotalPriceStatus(WalletConstants.TOTAL_PRICE_STATUS_FINAL)
+                        .setCurrencyCode(intent.getStringExtra("currencyCode"))
+                        .build())
+                .billingAddressRequired(intent.getBooleanExtra("billingAddressRequired", false))
+                .googleMerchantId(intent.getStringExtra("googleMerchantID"));
+
+        GooglePayment.requestPayment(braintreeFragment, request);
+    }
+
+    protected void requestApplePayNonce() {
+        // Apple Pay is not available on Android
+        Intent result = new Intent();
+        result.putExtra("error", new Exception("Apple Pay is not available on Android devices"));
+        setResult(2, result);
+        finish();
     }
 
     public void onPaymentMethodNonceCreated(PaymentMethodNonce paymentMethodNonce) {

--- a/android/src/main/java/com/example/flutter_braintree/FlutterBraintreePlugin.java
+++ b/android/src/main/java/com/example/flutter_braintree/FlutterBraintreePlugin.java
@@ -4,8 +4,12 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 
+import com.braintreepayments.api.dropin.DropInActivity;
+import com.braintreepayments.api.dropin.DropInRequest;
+import com.braintreepayments.api.dropin.DropInResult;
+import com.braintreepayments.api.models.PaymentMethodNonce;
 
-
+import java.util.ArrayList;
 import java.util.Map;
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
@@ -105,9 +109,35 @@ public class FlutterBraintreePlugin implements FlutterPlugin, ActivityAware, Met
       intent.putExtra("amount", (String) request.get("amount"));
       intent.putExtra("currencyCode", (String) request.get("currencyCode"));
       intent.putExtra("displayName", (String) request.get("displayName"));
+      intent.putExtra("isShippingAddressRequired", (Boolean) request.get("isShippingAddressRequired"));
       intent.putExtra("payPalPaymentIntent", (String) request.get("payPalPaymentIntent"));
       intent.putExtra("payPalPaymentUserAction", (String) request.get("payPalPaymentUserAction"));
       intent.putExtra("billingAgreementDescription", (String) request.get("billingAgreementDescription"));
+      activity.startActivityForResult(intent, CUSTOM_ACTIVITY_REQUEST_CODE);
+    } else if (call.method.equals("requestGooglePayNonce")) {
+      String authorization = call.argument("authorization");
+      Intent intent = new Intent(activity, FlutterBraintreeCustom.class);
+      intent.putExtra("type", "requestGooglePayNonce");
+      intent.putExtra("authorization", (String) call.argument("authorization"));
+      assert(call.argument("request") instanceof Map);
+      Map request = (Map) call.argument("request");
+      intent.putExtra("totalPrice", (String) request.get("totalPrice"));
+      intent.putExtra("currencyCode", (String) request.get("currencyCode"));
+      intent.putExtra("billingAddressRequired", (Boolean) request.get("billingAddressRequired"));
+      intent.putExtra("googleMerchantID", (String) request.get("googleMerchantID"));
+      activity.startActivityForResult(intent, CUSTOM_ACTIVITY_REQUEST_CODE);
+    } else if (call.method.equals("requestApplePayNonce")) {
+      String authorization = call.argument("authorization");
+      Intent intent = new Intent(activity, FlutterBraintreeCustom.class);
+      intent.putExtra("type", "requestApplePayNonce");
+      intent.putExtra("authorization", (String) call.argument("authorization"));
+      assert(call.argument("request") instanceof Map);
+      Map request = (Map) call.argument("request");
+      intent.putExtra("displayName", (String) request.get("displayName"));
+      intent.putExtra("currencyCode", (String) request.get("currencyCode"));
+      intent.putExtra("countryCode", (String) request.get("countryCode"));
+      intent.putExtra("merchantIdentifier", (String) request.get("merchantIdentifier"));
+      intent.putStringArrayListExtra("supportedNetworks", (ArrayList<String>) request.get("supportedNetworks"));
       activity.startActivityForResult(intent, CUSTOM_ACTIVITY_REQUEST_CODE);
     } else {
       result.notImplemented();

--- a/ios/Classes/FlutterBraintreeCustomPlugin.swift
+++ b/ios/Classes/FlutterBraintreeCustomPlugin.swift
@@ -2,8 +2,13 @@ import Flutter
 import UIKit
 import Braintree
 import BraintreeDropIn
+import PassKit
 
 public class FlutterBraintreeCustomPlugin: BaseFlutterBraintreePlugin, FlutterPlugin, BTViewControllerPresentingDelegate {
+
+    private var currentFlutterResult: FlutterResult?
+    private var currentAuthorization: String?
+
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "flutter_braintree.custom", binaryMessenger: registrar.messenger())
         
@@ -24,21 +29,23 @@ public class FlutterBraintreeCustomPlugin: BaseFlutterBraintreePlugin, FlutterPl
             isHandlingResult = false
             return
         }
-        
+
+        currentAuthorization = authorization
         let client = BTAPIClient(authorization: authorization)
-        
+
         if call.method == "requestPaypalNonce" {
             let driver = BTPayPalDriver(apiClient: client!)
-            
+
             guard let requestInfo = dict(for: "request", in: call) else {
                 isHandlingResult = false
                 return
             }
-            
+
             if let amount = requestInfo["amount"] as? String {
                 let paypalRequest = BTPayPalCheckoutRequest(amount: amount)
                 paypalRequest.currencyCode = requestInfo["currencyCode"] as? String
                 paypalRequest.displayName = requestInfo["displayName"] as? String
+                paypalRequest.isShippingAddressRequired = requestInfo["isShippingAddressRequired"] != nil ? requestInfo["isShippingAddressRequired"]! as! Bool : false
                 paypalRequest.billingAgreementDescription = requestInfo["billingAgreementDescription"] as? String
                 if let intent = requestInfo["payPalPaymentIntent"] as? String {
                     switch intent {
@@ -66,35 +73,148 @@ public class FlutterBraintreeCustomPlugin: BaseFlutterBraintreePlugin, FlutterPl
                 let paypalRequest = BTPayPalVaultRequest()
                 paypalRequest.displayName = requestInfo["displayName"] as? String
                 paypalRequest.billingAgreementDescription = requestInfo["billingAgreementDescription"] as? String
-                
+                paypalRequest.isShippingAddressRequired = requestInfo["isShippingAddressRequired"] != nil ? requestInfo["isShippingAddressRequired"]! as! Bool : false
+
                 driver.tokenizePayPalAccount(with: paypalRequest) { (nonce, error) in
                     self.handleResult(nonce: nonce, error: error, flutterResult: result)
                     self.isHandlingResult = false
                 }
             }
-            
+
         } else if call.method == "tokenizeCreditCard" {
             let cardClient = BTCardClient(apiClient: client!)
-            
+
             guard let cardRequestInfo = dict(for: "request", in: call) else {return}
-            
+
             let card = BTCard()
             card.number = cardRequestInfo["cardNumber"] as? String
             card.expirationMonth = cardRequestInfo["expirationMonth"] as? String
             card.expirationYear = cardRequestInfo["expirationYear"] as? String
             card.cvv = cardRequestInfo["cvv"] as? String
             card.cardholderName = cardRequestInfo["cardholderName"] as? String
-            
+
             cardClient.tokenizeCard(card) { (nonce, error) in
                 self.handleResult(nonce: nonce, error: error, flutterResult: result)
                 self.isHandlingResult = false
             }
+        } else if call.method == "requestApplePayNonce" {
+            guard let requestInfo = dict(for: "request", in: call) else {
+                isHandlingResult = false
+                return
+            }
+
+            let merchantIdentifier = requestInfo["merchantIdentifier"] as? String ?? ""
+
+            // Get supported networks from request
+            var supportedNetworks: [PKPaymentNetwork] = []
+            if let networks = requestInfo["supportedNetworks"] as? [Int] {
+                supportedNetworks = networks.compactMap { network in
+                    switch network {
+                    case 0: return PKPaymentNetwork.visa
+                    case 1: return PKPaymentNetwork.masterCard
+                    case 2: return PKPaymentNetwork.amex
+                    case 3: return PKPaymentNetwork.discover
+                    default: return nil
+                    }
+                }
+            }
+
+            // Check if Apple Pay is available for this merchant
+            let canMakePayments = PKPaymentAuthorizationController.canMakePayments()
+            let canMakePaymentsWithMerchant = PKPaymentAuthorizationController.canMakePayments(usingNetworks: supportedNetworks)
+
+            if !canMakePayments {
+                result(FlutterError(code: "APPLE_PAY_ERROR",
+                                  message: "Apple Pay is not available on this device. Please check if Apple Pay is set up in your device settings.",
+                                  details: nil))
+                isHandlingResult = false
+                return
+            }
+
+            if !canMakePaymentsWithMerchant {
+                result(FlutterError(code: "APPLE_PAY_ERROR",
+                                  message: "Apple Pay is not available for merchant: \(merchantIdentifier). Please check your Apple Pay configuration in Xcode and Apple Developer account.",
+                                  details: nil))
+                isHandlingResult = false
+                return
+            }
+
+            let paymentRequest = PKPaymentRequest()
+            paymentRequest.merchantIdentifier = merchantIdentifier
+            paymentRequest.countryCode = requestInfo["countryCode"] as? String ?? "US"
+            paymentRequest.currencyCode = requestInfo["currencyCode"] as? String ?? "USD"
+            paymentRequest.supportedNetworks = supportedNetworks
+
+            if let paymentSummaryItems = requestInfo["paymentSummaryItems"] as? [[String: Any]] {
+                paymentRequest.paymentSummaryItems = paymentSummaryItems.compactMap { item in
+                    guard let label = item["label"] as? String,
+                          let amount = item["amount"] as? Double,
+                          let typeRaw = item["type"] as? Int else {
+                        return nil
+                    }
+
+                    let _: PKPaymentSummaryItemType = typeRaw == 0 ? .final : .pending
+                    return PKPaymentSummaryItem(label: label, amount: NSDecimalNumber(value: amount))
+                }
+            }
+
+            // Check if the merchant identifier is valid
+            guard !paymentRequest.merchantIdentifier.isEmpty else {
+                result(FlutterError(code: "APPLE_PAY_ERROR",
+                                  message: "Merchant identifier is required",
+                                  details: nil))
+                isHandlingResult = false
+                return
+            }
+
+            // Check if we have payment summary items
+            guard !paymentRequest.paymentSummaryItems.isEmpty else {
+                result(FlutterError(code: "APPLE_PAY_ERROR",
+                                  message: "At least one payment summary item is required",
+                                  details: nil))
+                isHandlingResult = false
+                return
+            }
+
+            // Add merchant capabilities
+            paymentRequest.merchantCapabilities = .capability3DS
+
+            // Try to initialize the controller
+            guard let applePayController = PKPaymentAuthorizationViewController(paymentRequest: paymentRequest) else {
+                result(FlutterError(code: "APPLE_PAY_ERROR",
+                                  message: "Failed to initialize Apple Pay.",
+                                  details: nil))
+                isHandlingResult = false
+                return
+            }
+
+            // Set the delegate
+            applePayController.delegate = self
+
+            // Present the controller
+            if let rootViewController = UIApplication.shared.keyWindow?.rootViewController {
+                rootViewController.present(applePayController, animated: true) {
+                    print("Apple Pay sheet presented successfully")
+                }
+                self.currentFlutterResult = result
+            } else {
+                result(FlutterError(code: "APPLE_PAY_ERROR",
+                                  message: "No root view controller found to present Apple Pay",
+                                  details: nil))
+                isHandlingResult = false
+            }
+        } else if call.method == "requestGooglePayNonce" {
+            // Google Pay is not available on iOS
+            result(FlutterError(code: "GOOGLE_PAY_ERROR",
+                              message: "Google Pay is not available on iOS devices",
+                              details: nil))
+            isHandlingResult = false
         } else {
             result(FlutterMethodNotImplemented)
             self.isHandlingResult = false
         }
     }
-    
+
     private func handleResult(nonce: BTPaymentMethodNonce?, error: Error?, flutterResult: FlutterResult) {
         if error != nil {
             returnBraintreeError(result: flutterResult, error: error!)
@@ -111,5 +231,40 @@ public class FlutterBraintreeCustomPlugin: BaseFlutterBraintreePlugin, FlutterPl
     
     public func paymentDriver(_ driver: Any, requestsDismissalOf viewController: UIViewController) {
         
+    }
+}
+
+extension FlutterBraintreeCustomPlugin: PKPaymentAuthorizationViewControllerDelegate {
+    public func paymentAuthorizationViewController(_ controller: PKPaymentAuthorizationViewController, didAuthorizePayment payment: PKPayment, handler completion: @escaping (PKPaymentAuthorizationResult) -> Void) {
+        guard let authorization = currentAuthorization,
+              let client = BTAPIClient(authorization: authorization) else {
+            completion(PKPaymentAuthorizationResult(status: .failure, errors: nil))
+            return
+        }
+
+        let applePayClient = BTApplePayClient(apiClient: client)
+        applePayClient.tokenizeApplePay(payment) { (nonce, error) in
+            if let error = error {
+                completion(PKPaymentAuthorizationResult(status: .failure, errors: [error]))
+                return
+            }
+
+            if let nonce = nonce {
+                self.handleResult(nonce: nonce, error: nil, flutterResult: self.currentFlutterResult!)
+                completion(PKPaymentAuthorizationResult(status: .success, errors: nil))
+            } else {
+                completion(PKPaymentAuthorizationResult(status: .failure, errors: nil))
+            }
+        }
+    }
+
+    public func paymentAuthorizationViewControllerDidFinish(_ controller: PKPaymentAuthorizationViewController) {
+        controller.dismiss(animated: true) {
+            if self.currentFlutterResult != nil {
+                self.currentFlutterResult!(nil)
+                self.currentFlutterResult = nil
+            }
+            self.isHandlingResult = false
+        }
     }
 }

--- a/lib/src/custom.dart
+++ b/lib/src/custom.dart
@@ -45,4 +45,42 @@ class Braintree {
     if (result == null) return null;
     return BraintreePaymentMethodNonce.fromJson(result);
   }
+
+  /// Requests a Google Pay payment method nonce directly without the drop-in UI.
+  ///
+  /// [authorization] must be either a valid client token or a valid tokenization key.
+  /// [request] should contain all the information necessary for the Google Pay request.
+  ///
+  /// Returns a [Future] that resolves to a [BraintreePaymentMethodNonce] if the user confirmed the request,
+  /// or `null` if the user canceled the payment flow.
+  static Future<BraintreePaymentMethodNonce?> requestGooglePayNonce(
+      String authorization,
+      BraintreeGooglePaymentRequest request,
+      ) async {
+    final result = await _kChannel.invokeMethod('requestGooglePayNonce', {
+      'authorization': authorization,
+      'request': request.toJson(),
+    });
+    if (result == null) return null;
+    return BraintreePaymentMethodNonce.fromJson(result);
+  }
+
+  /// Requests an Apple Pay payment method nonce directly without the drop-in UI.
+  ///
+  /// [authorization] must be either a valid client token or a valid tokenization key.
+  /// [request] should contain all the information necessary for the Apple Pay request.
+  ///
+  /// Returns a [Future] that resolves to a [BraintreePaymentMethodNonce] if the user confirmed the request,
+  /// or `null` if the user canceled the payment flow.
+  static Future<BraintreePaymentMethodNonce?> requestApplePayNonce(
+      String authorization,
+      BraintreeApplePayRequest request,
+      ) async {
+    final result = await _kChannel.invokeMethod('requestApplePayNonce', {
+      'authorization': authorization,
+      'request': request.toJson(),
+    });
+    if (result == null) return null;
+    return BraintreePaymentMethodNonce.fromJson(result);
+  }
 }

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -196,6 +196,7 @@ class BraintreePayPalRequest {
     required this.amount,
     this.currencyCode,
     this.displayName,
+    this.isShippingAddressRequired = false,
     this.billingAgreementDescription,
     this.payPalPaymentIntent = PayPalPaymentIntent.authorize,
     this.payPalPaymentUserAction = PayPalPaymentUserAction.default_,
@@ -221,6 +222,9 @@ class BraintreePayPalRequest {
   /// for additional documentation.
   PayPalPaymentUserAction payPalPaymentUserAction;
 
+  /// Defaults to false. When set to true, the shipping address selector will be displayed.
+  bool isShippingAddressRequired = false;
+
   /// Converts this request object into a JSON-encodable format.
   Map<String, dynamic> toJson() => {
         if (amount != null) 'amount': amount,
@@ -230,6 +234,7 @@ class BraintreePayPalRequest {
           'billingAgreementDescription': billingAgreementDescription,
         'payPalPaymentIntent': payPalPaymentIntent.name,
         'payPalPaymentUserAction': payPalPaymentUserAction.name,
+        'isShippingAddressRequired': isShippingAddressRequired,
       };
 }
 


### PR DESCRIPTION
### Summary

This PR enhances the `flutter_braintree` package with the following major improvements:

1. **Standalone Nonce Support for Apple Pay and Google Pay**
2. **`isShippingAddressRequired` flag for PayPal Nonce Requests**

These features enable a more flexible and customizable integration of Braintree payment methods, eliminating the dependency on the Drop-in UI for common use cases.

---

### What's New

#### 🚀 Apple Pay & Google Pay
- Added two new methods:
  - `requestApplePayNonce()`
  - `requestGooglePayNonce()`

- These methods allow developers to trigger Apple Pay and Google Pay flows **without showing the Drop-in UI**, enabling tighter control over payment experience (e.g., using custom buttons).

- **Platform Support:**
  - iOS: Utilizes Apple Pay integration via Braintree SDK.
  - Android: Leverages Google Pay integration from the Braintree Android SDK.

#### 📦 PayPal Enhancements
- Added a new boolean parameter `isShippingAddressRequired` to `BraintreePayPalRequest`.

---

### Motivation

- Apps often have dedicated **Apple Pay** and **Google Pay** buttons (as per design guidelines and native UI practices). Forcing users to open a Drop-in sheet again adds redundancy and hurts UX.
- Developers need **fine-grained control** over what user data is collected during PayPal payments. The `isShippingAddressRequired` flag solves this.

---

### Backward Compatibility

✅ All existing functionality remains unchanged.  
✅ Drop-in UI still works as expected.  
✅ The new methods and flag are **optional** and additive.

---